### PR TITLE
Add basic tests for model functions

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(degradr)
+
+test_check("degradr")

--- a/tests/testthat/test_fit_healthindex.R
+++ b/tests/testthat/test_fit_healthindex.R
@@ -1,13 +1,12 @@
 library(degradr)
-
-set.seed(123)
-
+library(dplyr)
 test_that("fit_healthindex returns healthindex object", {
-  data <- data.frame(
-    unit = rep(1:2, each = 3),
-    t = rep(1:3, 2),
-    s1 = c(2, 3, 4, 2, 3, 4)
-  )
+  data <- train_FD001 %>%
+    select(unit,t,T24,T50,P30,
+           Nf,Ps30,phi, NRf,
+           BPR,htBleed,
+           W31, W32) %>%
+    mutate(across(c(P30,phi,W31,W32), ~ . * -1))
   hi <- fit_healthindex(data)
   expect_s3_class(hi, "healthindex")
   expect_true(all(c("index", "model") %in% names(hi)))

--- a/tests/testthat/test_fit_healthindex.R
+++ b/tests/testthat/test_fit_healthindex.R
@@ -1,0 +1,14 @@
+library(degradr)
+
+set.seed(123)
+
+test_that("fit_healthindex returns healthindex object", {
+  data <- data.frame(
+    unit = rep(1:2, each = 3),
+    t = rep(1:3, 2),
+    s1 = c(2, 3, 4, 2, 3, 4)
+  )
+  hi <- fit_healthindex(data)
+  expect_s3_class(hi, "healthindex")
+  expect_true(all(c("index", "model") %in% names(hi)))
+})

--- a/tests/testthat/test_fit_model.R
+++ b/tests/testthat/test_fit_model.R
@@ -3,12 +3,8 @@ library(degradr)
 set.seed(123)
 
 test_that("fit_model returns degradation_model", {
-  data <- data.frame(
-    unit = rep(1:2, each = 3),
-    t = rep(1:3, 2),
-    x = c(2, 3, 4, 2, 3, 4)
-  )
-  model <- fit_model(data)
+  colnames(filter_train) <- c("t", "x", "unit")
+  model <- fit_model(filter_train)
   expect_s3_class(model, "degradation_model")
   expect_true(all(c("u0", "Sigma0", "sigma2", "phi") %in% names(model)))
 })

--- a/tests/testthat/test_fit_model.R
+++ b/tests/testthat/test_fit_model.R
@@ -1,0 +1,14 @@
+library(degradr)
+
+set.seed(123)
+
+test_that("fit_model returns degradation_model", {
+  data <- data.frame(
+    unit = rep(1:2, each = 3),
+    t = rep(1:3, 2),
+    x = c(2, 3, 4, 2, 3, 4)
+  )
+  model <- fit_model(data)
+  expect_s3_class(model, "degradation_model")
+  expect_true(all(c("u0", "Sigma0", "sigma2", "phi") %in% names(model)))
+})

--- a/tests/testthat/test_predict_rul.R
+++ b/tests/testthat/test_predict_rul.R
@@ -1,0 +1,15 @@
+library(degradr)
+
+set.seed(123)
+
+test_that("predict_rul returns expected columns", {
+  data <- data.frame(
+    unit = rep(1:2, each = 3),
+    t = rep(1:3, 2),
+    x = c(2, 3, 4, 2, 3, 4)
+  )
+  model <- fit_model(data)
+  preds <- predict_rul(data, model)
+  expect_s3_class(preds, "data.frame")
+  expect_true(all(c("unit", "RUL") %in% colnames(preds)))
+})

--- a/tests/testthat/test_predict_rul.R
+++ b/tests/testthat/test_predict_rul.R
@@ -3,13 +3,9 @@ library(degradr)
 set.seed(123)
 
 test_that("predict_rul returns expected columns", {
-  data <- data.frame(
-    unit = rep(1:2, each = 3),
-    t = rep(1:3, 2),
-    x = c(2, 3, 4, 2, 3, 4)
-  )
-  model <- fit_model(data)
-  preds <- predict_rul(data, model)
-  expect_s3_class(preds, "data.frame")
-  expect_true(all(c("unit", "RUL") %in% colnames(preds)))
+  colnames(filter_train) <- c("t", "x", "unit")
+  colnames(filter_test)  <- c("t", "x", "unit", "RUL")
+  model <- fit_model(data = filter_train, type = "exponential", degree = 1)
+  pred <- predict_rul(data = filter_test, model = model, D = 600)
+  expect_true(all(c("unit", "RUL") %in% colnames(pred)))
 })


### PR DESCRIPTION
## Summary
- add `testthat` infrastructure and tests for `fit_model`, `predict_rul`, and `fit_healthindex`

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e382b52c832caa0edb3348b0d420