### PR TITLE
Vectorize prul function to support multiple units

### DIFF
--- a/R/prul.R
+++ b/R/prul.R
@@ -1,49 +1,63 @@
 
-prul <- function(t,data,model,D = NULL){
+prul <- function(t, data, model, D = NULL) {
   if (inherits(model, "healthindex")) {
     data_index <- log_transform(data = data, phi_list = model$index$phi)
     data <- data_index %>%
-      mutate(x = as.vector(as.matrix(select(.,-unit,-t)) %*% model$index$w)) %>%
-      select(unit,t,x)
+      mutate(x = as.vector(as.matrix(select(., -unit, -t)) %*% model$index$w)) %>%
+      select(unit, t, x)
     model <- model$model
   }
-  tt <- data$t
-  x <- data$x
-  n <- max(tt)
-  post <- posterior(model = model, t = tt, x = x)
-  u1 <- post$u1
-  sigma1 <- post$sigma1
-  sigma2 <- model$sigma2
-  ud <- model$ud
-  vd <- model$vd
-  p <- model$degree
-  if(class(model) == "healthindex"){
-    type = model$model$type
-  }else{
-    type <- model$type
+
+  if (!all(c("t", "x", "unit") %in% colnames(data))) {
+    stop("Input data must have columns: 't', 'x', and 'unit'")
   }
 
-  if(type == "exponential"){
-    if(is.null(D)){
-      value <- RLD_random(t = t, n = n, u1 = u1, sigma1 = sigma1,
-                 sigma2 = sigma2, ud = ud, vd = vd, p = p)
-    }else{
-      phi <- model$phi
-      D_trans <- log(D - phi)
-      value <- RLD(t = t, n = n, u1 = u1,
-                      sigma1 = sigma1, sigma2 = sigma2,
-                      p = p,D = D_trans)
+  units_list <- split(data, data$unit)
+
+  predict_one <- function(unit_data) {
+    tt <- unit_data$t
+    x <- unit_data$x
+    n <- max(tt)
+    post <- posterior(model = model, t = tt, x = x)
+    u1 <- post$u1
+    sigma1 <- post$sigma1
+    sigma2 <- model$sigma2
+    ud <- model$ud
+    vd <- model$vd
+    p <- model$degree
+    type <- model$type
+
+    if (type == "exponential") {
+      if (is.null(D)) {
+        value <- RLD_random(t = t, n = n, u1 = u1, sigma1 = sigma1,
+                            sigma2 = sigma2, ud = ud, vd = vd, p = p)
+      } else {
+        phi <- model$phi
+        D_trans <- log(D - phi)
+        value <- RLD(t = t, n = n, u1 = u1,
+                     sigma1 = sigma1, sigma2 = sigma2,
+                     p = p, D = D_trans)
+      }
+    } else {
+      if (is.null(D)) {
+        value <- RLD_random(t = t, n = n, u1 = u1, sigma1 = sigma1,
+                            sigma2 = sigma2, ud = ud, vd = vd, p = p)
+      } else {
+        value <- RLD(t = t, n = n, u1 = u1,
+                     sigma1 = sigma1, sigma2 = sigma2,
+                     p = p, D = D)
+      }
     }
-  }else{
-    if(is.null(D)){
-      value <- RLD_random(t = t, n = n, u1 = u1, sigma1 = sigma1,
-                 sigma2 = sigma2, ud = ud, vd = vd, p = p)
-    }else{
-      value <- RLD(t = t, n = n, u1 = u1,
-                   sigma1 = sigma1, sigma2 = sigma2,
-                   p = p,D = D)
-    }
+
+    data.frame(
+      unit = unique(unit_data$unit),
+      PRUL = value
+    )
   }
-  return(value)
+
+  results <- lapply(units_list, predict_one)
+  results_df <- dplyr::bind_rows(results)
+
+  return(results_df)
 }
 

--- a/man/prul.Rd
+++ b/man/prul.Rd
@@ -4,14 +4,14 @@
 Probability of Remaining Useful Life (RUL) Falling Within a Time Horizon
 }
 \description{
-Evaluates the cumulative probability that the Remaining Useful Life (RUL) of a unit is less than or equal to a specified time \code{t}. The computation is based on a fitted degradation model and the observed degradation signal for the unit.
+Evaluates the cumulative probability that the Remaining Useful Life (RUL) of one or more units is less than or equal to a specified time \code{t}. The computation is based on a fitted degradation model and the observed degradation signals for the units.
 }
 \usage{
 prul(t, data, model, D = NULL)
 }
 \arguments{
   \item{t}{Time at which to evaluate the RUL cumulative distribution function.}
-  \item{data}{A data frame with columns \code{t} (time), \code{x} (degradation measurement), and \code{unit} (unit identifier) for a single unit. If \code{model} is of class \code{"healthindex"}, the multivariate sensor data should be supplied and the health index will be constructed internally.}
+  \item{data}{A data frame with columns \code{t} (time), \code{x} (degradation measurement), and \code{unit} (unit identifier) for one or more units. If \code{model} is of class \code{"healthindex"}, provide the multivariate sensor data; the health index will be constructed internally.}
   \item{model}{An object of class \code{"degradation_model"} produced by \code{\link{fit_model}} or a \code{"healthindex"} object returned by \code{\link{fit_healthindex}}.}
   \item{D}{Optional critical degradation threshold. If provided, a fixed-threshold model is used; otherwise a random-threshold model is assumed. For exponential models the threshold is automatically transformed to the log scale.}
 }
@@ -19,7 +19,9 @@ prul(t, data, model, D = NULL)
 For a fixed threshold model (\code{D} supplied), the function computes the Remaining Life Distribution (RLD) using the specified failure threshold. If \code{D} is \code{NULL}, the distribution is computed under a random-threshold formulation based on the training data.
 }
 \value{
-Numeric value between 0 and 1 giving \eqn{P(\mathrm{RUL} \le t)}.
+A data frame with one row per unit containing:
+\item{unit}{Unit identifier.}
+\item{PRUL}{Cumulative probability that \eqn{\mathrm{RUL} \le t}.}
 }
 \seealso{\code{\link{qrul}}, \code{\link{predict_rul}}}
 \examples{
@@ -37,9 +39,9 @@ colnames(filter_test)  <- c("t", "x", "unit", "RUL")
 # Fit an exponential mixed-effects model of degree 1
 model <- fit_model(data = filter_train, type = "exponential", degree = 1)
 
-# Probability that unit 1 fails within 50 cycles given a failure threshold D = 600
+# Probability that each unit fails within 50 cycles given a failure threshold D = 600
 prul(t = 50,
-     data = subset(filter_test, unit == 1),
+     data = filter_test,
      model = model, D = 600)
 }
 }

--- a/tests/testthat/test_prul.R
+++ b/tests/testthat/test_prul.R
@@ -1,0 +1,11 @@
+library(degradr)
+
+set.seed(123)
+
+test_that("prul returns expected columns", {
+  colnames(filter_train) <- c("t", "x", "unit")
+  colnames(filter_test)  <- c("t", "x", "unit", "RUL")
+  model <- fit_model(data = filter_train, type = "exponential", degree = 1)
+  prob <- prul(t = 50, data = filter_test, model = model, D = 600)
+  expect_true(all(c("unit", "PRUL") %in% colnames(prob)))
+})


### PR DESCRIPTION
## Summary
- Vectorize `prul` to compute per-unit RUL probabilities for datasets with multiple units
- Document new vectorized behavior and usage example
- Add tests checking returned columns from `prul`

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4f3ef000832c9a516f26db88e5fb